### PR TITLE
Add a --disable-silence argument to disable the silence plugin.

### DIFF
--- a/lib/minitest/silence_plugin.rb
+++ b/lib/minitest/silence_plugin.rb
@@ -57,21 +57,26 @@ module Minitest
 
   class << self
     def plugin_silence_options(opts, options)
+      opts.on('--disable-silence', "Do not rebind standard IO") do
+        options[:disable_silence] = true
+      end
       opts.on('--fail-on-output', "Fail a test when it writes to STDOUT or STDERR") do
         options[:fail_on_output] = true
       end
     end
 
     def plugin_silence_init(options)
-      Minitest::Result.prepend(Minitest::Silence::ResultOutputPatch)
-      Minitest.singleton_class.prepend(Minitest::Silence::RunOneMethodPatch)
+      unless options[:disable_silence]
+        Minitest::Result.prepend(Minitest::Silence::ResultOutputPatch)
+        Minitest.singleton_class.prepend(Minitest::Silence::RunOneMethodPatch)
 
-      if options[:fail_on_output]
-        # We have to make sure this reporter runs as the first reporter, so it can still adjust
-        # the result and other reporters will take the change into account.
-        reporter.reporters.unshift(Minitest::Silence::FailOnOutputReporter.new(options[:io], options))
-      elsif options[:verbose]
-        reporter << Minitest::Silence::BoxedOutputReporter.new(options[:io], options)
+        if options[:fail_on_output]
+          # We have to make sure this reporter runs as the first reporter, so it can still adjust
+          # the result and other reporters will take the change into account.
+          reporter.reporters.unshift(Minitest::Silence::FailOnOutputReporter.new(options[:io], options))
+        elsif options[:verbose]
+          reporter << Minitest::Silence::BoxedOutputReporter.new(options[:io], options)
+        end
       end
     end
   end

--- a/test/integration/minitest_silence_integration_test.rb
+++ b/test/integration/minitest_silence_integration_test.rb
@@ -3,6 +3,27 @@
 require 'test_helper'
 
 class MinitestSilenceIntegrationTest < IntegrationTest
+  def test_disable_silence
+    process = spawn_test_process(
+      test_file: 'noisy_tests.rb',
+      arguments: ['--disable-silence', '-n', 'test_pass_with_noisy_stdout', '--seed', '123'],
+    ).value
+
+    assert_test_process_successful(process)
+    assert_equal <<~EOM, normalize_output(process.stdout)
+      Run options: --disable-silence -n test_pass_with_noisy_stdout --seed 123
+
+      # Running:
+
+      STDOUT noise
+      .
+
+      Finished in 0.012s, 0.012 runs/s, 0.012 assertions/s.
+
+      1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
+    EOM
+  end
+
   def test_noisy_tests_with_failure
     process = spawn_test_process(test_file: 'noisy_tests.rb').value
 
@@ -38,5 +59,11 @@ class MinitestSilenceIntegrationTest < IntegrationTest
   def test_debugger_is_noop
     process = spawn_test_process(test_file: 'test_with_debugger.rb').value
     assert_test_process_successful(process)
+  end
+
+  private
+
+  def normalize_output(string)
+    string.gsub(/\d+\.\d+/, '0.012')
   end
 end


### PR DESCRIPTION
This will cause output not to be redirected, and output to be written straight to STDOUT/STDERR. Also, STDIN will not be reopened, which mean you can do interactive things like using a debugger.

I am considering renaming the plugin to `minitest-capture` (and rename this command line option accordingly) so it is in line with the naming for the Python test runner: https://docs.pytest.org/en/stable/capture.html. 