### PR TITLE
Do not monkey patch `__run`, only patch `run_one_method`

### DIFF
--- a/lib/minitest/silence_plugin.rb
+++ b/lib/minitest/silence_plugin.rb
@@ -15,16 +15,11 @@ module Minitest
     end
 
     module RunOneMethodPatch
-      attr_reader :original_stdin, :original_stdout, :original_stderr
-
-      def __run(*)
-        @original_stdin = $stdin.dup
-        @original_stdout = $stdout.dup
-        @original_stderr = $stderr.dup
-        super
-      end
-
       def run_one_method(klass, method_name)
+        @original_stdin ||= $stdin.dup
+        @original_stdout ||= $stdout.dup
+        @original_stderr ||= $stderr.dup
+
         output_reader, output_writer = IO.pipe
         output_thread = Thread.new { output_reader.read }
 
@@ -35,9 +30,9 @@ module Minitest
 
           super
         ensure
-          $stdout.reopen(original_stdout)
-          $stderr.reopen(original_stderr)
-          $stdin.reopen(original_stdin)
+          $stdout.reopen(@original_stdout)
+          $stderr.reopen(@original_stderr)
+          $stdin.reopen(@original_stdin)
           output_writer.close
         end
 


### PR DESCRIPTION
`__run` and `run` both are likely to be monkeypatched by other plugins, and those patches may not call `super`. This breaks this plugin (with very unclear problems, because STDERR is suppressed).

By only monkeypatching `run_one_method`, we reduce the likelihood that other plugins interfere with this plugin. And even if somebody else monkeypatches this method without calling `super`, it would end up simply disabling the silence plugin, rather than breaking.