### PR TITLE
Manually close IO reader to reduce file handle issues.

### DIFF
--- a/lib/minitest/silence_plugin.rb
+++ b/lib/minitest/silence_plugin.rb
@@ -37,6 +37,7 @@ module Minitest
         end
 
         result.output = output_thread.value
+        output_reader.close
         result
       end
     end


### PR DESCRIPTION
I've been seeing open file handle issues when running this on a project with hundreds of tests on Ruby versions >= `2.7.0`.

```
.../ruby/2.7.2/gems/minitest-silence-0.2.1/lib/minitest/silence_plugin.rb:23:in `pipe': Too many open files (Errno::EMFILE)
```

I noticed that while we close the writer IO object manually, we were still relying on normal closing / GC closing for the reader IO handle object.

Adding a manual close call for it seems to have eliminated the file handle errors for me. I'm not well-versed in Ruby IO so this may not be the proper fix.