### PR TITLE
Move io reader close call to ensure block.

### DIFF
--- a/lib/minitest/silence_plugin.rb
+++ b/lib/minitest/silence_plugin.rb
@@ -37,8 +37,9 @@ module Minitest
         end
 
         result.output = output_thread.value
-        output_reader.close
         result
+      ensure
+        output_reader.close
       end
     end
 


### PR DESCRIPTION
We added a call to explicitly close an IO reader object in https://github.com/Shopify/minitest-silence/pull/7, but it's possible that an earlier method could throw an exception.

To be a bit more correct, this PR moves the close call into an Ensure block.

More context: https://github.com/Shopify/minitest-silence/pull/7/files#r526185538