### PR TITLE
Add ENV level disable via DISABLE_MINITEST_SILENCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ gem 'minitest-silence', require: false
 
 ## Usage
 
-The plugin will be automatically activated by Minitest if it is in your application's bundle.
+The plugin will be automatically loaded by Minitest if it is in your application's bundle.
 
-- By default, the captured output produced by tests will be discarded, so the output of the test runner will look like how it was intended.
+- By default, output will be written to `STDOUT` and `STDERR` normally for local test runs, and captured for CI runs. In CI (environments with `ENV["CI"]` set), out put will be captured and discarded, so the output of the test runner will look like how it was intended.
 -  If you run tests with the `--verbose` option , it will be nicely included in the test runner's output, inside a box that will tell you what test it originated from.
-- You can also run this plugin in "strict mode": by running tests with the `--fail-on-output` option, tests will fail if they produce any output to STDOUT or STDERR.
+- You can also run this plugin in "strict mode": by running tests with the `--fail-on-output` option, tests will fail if they produce any output to `STDOUT` or `STDERR`.
 
-You can disable the plugin by providing the `--disable-silence` command line option to your test invocation. The primary use case for this is when you want to use a debugger inside a test, which will require a the standard input and outputs to work interactively.
+You can enable the plugin in any environment by providing the `--enable-silence` command line option to your test invocation. The primary use case for this is when you want to silence output locally.
 
 ## Development
 

--- a/lib/minitest/silence_plugin.rb
+++ b/lib/minitest/silence_plugin.rb
@@ -54,8 +54,8 @@ module Minitest
 
   class << self
     def plugin_silence_options(opts, options)
-      opts.on('--disable-silence', "Do not rebind standard IO") do
-        options[:disable_silence] = true
+      opts.on('--enable-silence', "Rebind standard IO") do
+        options[:enable_silence] = true
       end
       opts.on('--fail-on-output', "Fail a test when it writes to STDOUT or STDERR") do
         options[:fail_on_output] = true
@@ -63,7 +63,7 @@ module Minitest
     end
 
     def plugin_silence_init(options)
-      unless options[:disable_silence]
+      if options[:enable_silence] || ENV["CI"]
         Minitest::Result.prepend(Minitest::Silence::ResultOutputPatch)
         Minitest.singleton_class.prepend(Minitest::Silence::RunOneMethodPatch)
 


### PR DESCRIPTION
Closes #3 

Adds support for an ENV level disable. I'm open to suggestions for alternatives, but adding what I outline in the readme should fix the common use-case for local development.